### PR TITLE
Fix undefined hash variable because of missing return

### DIFF
--- a/doc/gtm-tag-template.js
+++ b/doc/gtm-tag-template.js
@@ -68,7 +68,7 @@ const main = (data) => {
   if (typeof data.defaultConsent !== 'undefined')
   {
     data.defaultConsent.reduce((hash, item) => {
-      hash[item.consentName] = item.consentState;
+      return hash[item.consentName] = item.consentState;
     }, defaultConsentState);
   }
 


### PR DESCRIPTION
### 💬 Description

### 🎟️ Issue(s)
Leckerli cookie banner doesn't appear when setting up the template and tags because of a JS error.

### 🔢 To Review
Set up the tags using the following code and the cookie banner will appear.
