### PR TITLE
fix(gtm): Fix cookie parsing from getCookieValues()

### DIFF
--- a/doc/gtm-tag-template.js
+++ b/doc/gtm-tag-template.js
@@ -93,9 +93,13 @@ const main = (data) => {
   leckerliSettings.name = COOKIE_NAME;
 
   // Check if cookie is set and run updateLeckerliConsent()
-  const consent = JSON.parse(getCookieValues(leckerliSettings.name));
-  if (typeof consent !== 'undefined') {
-    updateLeckerliConsent(consent);
+  // getCookieValues() always returns an Array (empty when no cookie).
+  const cookieValues = getCookieValues(leckerliSettings.name);
+  if (cookieValues.length > 0) {
+    const consent = JSON.parse(cookieValues[0]);
+    if (typeof consent !== 'undefined') {
+      updateLeckerliConsent(consent);
+    }
   }
 
   // Set leckerli settings

--- a/doc/gtm-tag-template.tpl
+++ b/doc/gtm-tag-template.tpl
@@ -197,9 +197,13 @@ const main = (data) => {
   leckerliSettings.name = COOKIE_NAME;
 
   // Check if cookie is set and run updateLeckerliConsent()
-  const consent = JSON.parse(getCookieValues(leckerliSettings.name));
-  if (typeof consent !== 'undefined') {
-    updateLeckerliConsent(consent);
+  // getCookieValues() always returns an Array (empty when no cookie).
+  const cookieValues = getCookieValues(leckerliSettings.name);
+  if (cookieValues.length > 0) {
+    const consent = JSON.parse(cookieValues[0]);
+    if (typeof consent !== 'undefined') {
+      updateLeckerliConsent(consent);
+    }
   }
 
   // Set leckerli settings


### PR DESCRIPTION
### Description

`getCookieValues()` returns an array of matching cookie values, but the code was passing the entire array directly to `JSON.parse()`. This caused consent state not to be restored from the cookie on page load.

The fix checks the array length and parses only the first element (`cookieValues[0]`).

No more `Unexpected end of JSON input` error.